### PR TITLE
Fixed implementation of method to share links and modified instructions

### DIFF
--- a/Android/src/org/gmaxera/qtfacebook/QFacebookBinding.java
+++ b/Android/src/org/gmaxera/qtfacebook/QFacebookBinding.java
@@ -245,7 +245,7 @@ public class QFacebookBinding implements Session.StatusCallback {
 			m_instance.activity.runOnUiThread(new Runnable() {
 				public void run() {
 					FacebookDialog shareDialog = new FacebookDialog.ShareDialogBuilder(m_instance.activity)
-						.setApplicationName("IlRibelle.com")
+						.setApplicationName(getString(R.string.app_name))
 						.setLink(link)
 						.setName(linkName)
 						.setPicture(imageUrl)

--- a/Android/src/org/gmaxera/qtfacebook/QFacebookBinding.java
+++ b/Android/src/org/gmaxera/qtfacebook/QFacebookBinding.java
@@ -28,6 +28,14 @@ public class QFacebookBinding implements Session.StatusCallback {
 	private Activity activity = null;
 	// Used by Facebook SDK for handling UI transitions
 	private UiLifecycleHelper uiLifecycleHelper = null;
+	// A string set to the name of the Facebook dialog which we launched and
+	// for which we are expecting notification via the uiLifecycleHelper.
+	// Perhaps we should synchronize access to this variable? We could read
+	// and modify it from different threads (though it is not so likely)
+	private static String runningFacebookDialog;
+	// If this variable is not NULL, after a successful login is notified in
+	// call(), the operation is executed in the gui thread
+	private static Runnable postLoginOperation = null;
 	//! subset of requestPermissions that only allow reading from Facebook
 	ArrayList<String> readPermissions = new ArrayList<String>();
 	//! subset of requestPermissions that allow writing to Facebook
@@ -90,11 +98,13 @@ public class QFacebookBinding implements Session.StatusCallback {
 			@Override
 			public void onError(FacebookDialog.PendingCall pendingCall, Exception error, Bundle data) {
 				Log.e("Activity", String.format("Error: %s", error.toString()));
+				operationError(runningFacebookDialog, error.toString());
 			}
 
 			@Override
 			public void onComplete(FacebookDialog.PendingCall pendingCall, Bundle data) {
 				Log.i("Activity", "Success!");
+				operationDone(runningFacebookDialog, new String[0]);
 			}
 		});
 	}
@@ -225,17 +235,17 @@ public class QFacebookBinding implements Session.StatusCallback {
 	// the app. linkName is the name of the link, link is the link url, imageUrl is the url
 	// of the image associated wih the link.
 	static public void publishLinkViaShareDialog( final String linkName, final String link, final String imageUrl ) {
-		// Creating the session if it doesn't exist yet
-		createSessionIfNeeded();
-
 		// First of all checking if we can use the ShareDialog and using it if we can
 		if (FacebookDialog.canPresentShareDialog(m_instance.activity.getApplicationContext(), FacebookDialog.ShareDialogFeature.SHARE_DIALOG)) {
 			Log.i("QFacebook", "Publishing using Share Dialog");
+
+			runningFacebookDialog = "publishLinkViaShareDialog";
 
 			// Publish the post using the Share Dialog. We start the dialog from the UI thread
 			m_instance.activity.runOnUiThread(new Runnable() {
 				public void run() {
 					FacebookDialog shareDialog = new FacebookDialog.ShareDialogBuilder(m_instance.activity)
+						.setApplicationName("IlRibelle.com")
 						.setLink(link)
 						.setName(linkName)
 						.setPicture(imageUrl)
@@ -246,14 +256,14 @@ public class QFacebookBinding implements Session.StatusCallback {
 		} else {
 			Log.i("QFacebook", "Publishing using Feed Dialog");
 
-			// Falling back to using the Feed Dialog
+			// Falling back to using the Feed Dialog. We need to perform the login, first
+
+			// Creating the runnable to start after a successful login
 			final Bundle params = new Bundle();
 			params.putString("name", linkName);
 			params.putString("link", link);
 			params.putString("picture", imageUrl);
-
-			// Starting the Feed Dialog from the UI thread
-			m_instance.activity.runOnUiThread(new Runnable() {
+			postLoginOperation = new Runnable() {
 				public void run() {
 					WebDialog.FeedDialogBuilder feedDialogBuilder = new WebDialog.FeedDialogBuilder(m_instance.activity, Session.getActiveSession(), params);
 
@@ -266,16 +276,25 @@ public class QFacebookBinding implements Session.StatusCallback {
 								final String postId = values.getString("post_id");
 								if (postId != null) {
 									Log.i("QFacebook", "Posted story, id: "+postId);
+									String[] data = new String[2];
+									// We fill array with a key followed by a value, as
+									// that is how C++ expects stuffs
+									data[0] = "postId";
+									data[1] = postId;
+									operationDone("publishLinkViaShareDialog", data);
 								} else {
 									// User clicked the Cancel button
-									Log.i("QFacebook", "Publish cancelled");
+									Log.i("QFacebook", "Publication cancelled");
+									operationError("publishLinkViaShareDialog", "Publication cancelled");
 								}
 							} else if (error instanceof FacebookOperationCanceledException) {
 								// User clicked the "x" button
 								Log.i("QFacebook", "Publish cancelled");
+								operationError("publishLinkViaShareDialog", "Publication cancelled");
 							} else {
 								// Generic, ex: network error
 								Log.e("QFacebook", "Error posting story");
+								operationError("publishLinkViaShareDialog", "Error posting story");
 							}
 						}
 					});
@@ -283,7 +302,10 @@ public class QFacebookBinding implements Session.StatusCallback {
 					WebDialog feedDialog = feedDialogBuilder.build();
 					feedDialog.show();
 				}
-			});
+			};
+
+			// Logging in. If login is successful, the postLoginOperation will be executed
+			login();
 		}
 	}
 
@@ -305,6 +327,8 @@ public class QFacebookBinding implements Session.StatusCallback {
 	// The Session.StatusCallback method
 	@Override
 	public void call(Session session, SessionState state, Exception exception) {
+		Log.i("QFacebook", "Inside the StatusCallback method");
+
 		// check if there was an exception
 		if (exception != null) {
 			if (exception instanceof FacebookOperationCanceledException &&
@@ -312,6 +336,7 @@ public class QFacebookBinding implements Session.StatusCallback {
 				// HERE THE USER DID NOT ACCEPT SOMETHING
 				Log.i("QFacebook", "The user did not accept something...");
 			} else {
+				// qui forse fare logout o segnare come logged out
 				exception.printStackTrace();
 				Throwable cause = exception;
 				System.err.println(exception.getMessage());
@@ -324,6 +349,7 @@ public class QFacebookBinding implements Session.StatusCallback {
 		// check the current state and acts accordlying
 		List<String> grantedPermissions;
 		String[] perms;
+		boolean runPostLoginOperation = false;
 		switch (state) {
 		case CLOSED:
 			Log.i("QFacebook", "Facebook State is CLOSED");
@@ -350,13 +376,20 @@ public class QFacebookBinding implements Session.StatusCallback {
 			grantedPermissions = session.getPermissions();
 			perms = grantedPermissions.toArray(new String[grantedPermissions.size()]);
 			onFacebookStateChanged( 3, perms );
+			runPostLoginOperation = true;
 		break;
 		case OPENED_TOKEN_UPDATED:
 			Log.i("QFacebook", "Facebook State is OPENED_TOKEN_UPDATED");
 			grantedPermissions = session.getPermissions();
 			perms = grantedPermissions.toArray(new String[grantedPermissions.size()]);
 			onFacebookStateChanged( 4, perms );
+			runPostLoginOperation = true;
 		break;
+		}
+
+		if (runPostLoginOperation && (postLoginOperation != null)) {
+			m_instance.activity.runOnUiThread(postLoginOperation);
+			postLoginOperation = null;
 		}
 	}
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ How to use for Android platform
 The first part of the instructions depends on whether you are using gradle to build the android part or not
 
 * Using gradle
-** The Facebook android sdk is available from Maven Central, so you can avoid downloading the sdk directly. Simply open build.gradle and add the following lines just after "apply plugin: 'android'":
+  * The Facebook android sdk is available from Maven Central, so you can avoid downloading the sdk directly. Simply open build.gradle and add the following lines just after "apply plugin: 'android'":
 ```
 repositories {
 	mavenCentral()
@@ -67,17 +67,17 @@ compile 'com.facebook.android:facebook-android-sdk:3.+'
 inside the dependencies block (this will use the latest version of the facebook android sdk with major 3, you can substitute the + with a specific version or even remove the major for the latest version)
 
 * Not using gradle
-** Unzip the facebook android sdk package
-** Inside the unzipped directory, locate the subdirectory 'facebook' and copy it in another location (in a subdirectory of your Qt project it's fine)
-** Open the copied directory and in a command line window execute the following command to create a custom build.xml ant build file (select the version of android sdk you are using):
+  * Unzip the facebook android sdk package
+  * Inside the unzipped directory, locate the subdirectory 'facebook' and copy it in another location (in a subdirectory of your Qt project it's fine)
+  * Open the copied directory and in a command line window execute the following command to create a custom build.xml ant build file (select the version of android sdk you are using):
 ```
 android update project --path . --target android-19
 ```
-** Add to the Qt project a custom Android package source directory
+  * Add to the Qt project a custom Android package source directory
 ```
 ANDROID_PACKAGE_SOURCE_DIR = $$PWD/Android
 ```
-** In the Android package source directory add the project.properties file (or edit it) and append the following content (pay attention to android.library.reference.1, if you already added other library references you should ensure that the number is unique and progressive; moreover the path should be the relative path from your project android build directory to the directory with facebook sdk):
+  * In the Android package source directory add the project.properties file (or edit it) and append the following content (pay attention to android.library.reference.1, if you already added other library references you should ensure that the number is unique and progressive; moreover the path should be the relative path from your project android build directory to the directory with facebook sdk):
 ```
 # Project target.
 target=android-19

--- a/README.md
+++ b/README.md
@@ -51,17 +51,33 @@ How to use for Android platform
 ==========
 ## Prepare Facebook SDK for Android
 
-* Unzip the facebook android sdk package
-* Inside the unzipped directory, locate the subdirectory 'facebook' and copy it in another location (in a subdirectory of your Qt project it's fine)
-* Open the copied directory and in a command line window execute the following command to create a custom build.xml ant build file (select the version of android sdk you are using):
+The first part of the instructions depends on whether you are using gradle to build the android part or not
+
+* Using gradle
+** The Facebook android sdk is available from Maven Central, so you can avoid downloading the sdk directly. Simply open build.gradle and add the following lines just after "apply plugin: 'android'":
+```
+repositories {
+	mavenCentral()
+}
+```
+and the following line:
+```
+compile 'com.facebook.android:facebook-android-sdk:3.+'
+```
+inside the dependencies block (this will use the latest version of the facebook android sdk with major 3, you can substitute the + with a specific version or even remove the major for the latest version)
+
+* Not using gradle
+** Unzip the facebook android sdk package
+** Inside the unzipped directory, locate the subdirectory 'facebook' and copy it in another location (in a subdirectory of your Qt project it's fine)
+** Open the copied directory and in a command line window execute the following command to create a custom build.xml ant build file (select the version of android sdk you are using):
 ```
 android update project --path . --target android-19
 ```
-* Add to the Qt project a custom Android package source directory
+** Add to the Qt project a custom Android package source directory
 ```
 ANDROID_PACKAGE_SOURCE_DIR = $$PWD/Android
 ```
-* In the Android package source directory add the project.properties file (or edit it) and append the following content (pay attention to android.library.reference.1, if you already added other library references you should ensure that the number is unique and progressive; moreover the path should be the relative path from your project android build directory to the directory with facebook sdk):
+** In the Android package source directory add the project.properties file (or edit it) and append the following content (pay attention to android.library.reference.1, if you already added other library references you should ensure that the number is unique and progressive; moreover the path should be the relative path from your project android build directory to the directory with facebook sdk):
 ```
 # Project target.
 target=android-19

--- a/README.md
+++ b/README.md
@@ -53,8 +53,8 @@ How to use for Android platform
 
 The first part of the instructions depends on whether you are using gradle to build the android part or not
 
-* Using gradle
-  * The Facebook android sdk is available from Maven Central, so you can avoid downloading the sdk directly. Simply open build.gradle and add the following lines just after "apply plugin: 'android'":
+### Using gradle
+The Facebook android sdk is available from Maven Central, so you can avoid downloading the sdk directly. Simply open build.gradle and add the following lines just after "apply plugin: 'android'":
 ```
 repositories {
 	mavenCentral()
@@ -66,24 +66,26 @@ compile 'com.facebook.android:facebook-android-sdk:3.+'
 ```
 inside the dependencies block (this will use the latest version of the facebook android sdk with major 3, you can substitute the + with a specific version or even remove the major for the latest version)
 
-* Not using gradle
-  * Unzip the facebook android sdk package
-  * Inside the unzipped directory, locate the subdirectory 'facebook' and copy it in another location (in a subdirectory of your Qt project it's fine)
-  * Open the copied directory and in a command line window execute the following command to create a custom build.xml ant build file (select the version of android sdk you are using):
+### Not using gradle
+* Unzip the facebook android sdk package
+* Inside the unzipped directory, locate the subdirectory 'facebook' and copy it in another location (in a subdirectory of your Qt project it's fine)
+* Open the copied directory and in a command line window execute the following command to create a custom build.xml ant build file (select the version of android sdk you are using):
 ```
 android update project --path . --target android-19
 ```
-  * Add to the Qt project a custom Android package source directory
+* Add to the Qt project a custom Android package source directory
 ```
 ANDROID_PACKAGE_SOURCE_DIR = $$PWD/Android
 ```
-  * In the Android package source directory add the project.properties file (or edit it) and append the following content (pay attention to android.library.reference.1, if you already added other library references you should ensure that the number is unique and progressive; moreover the path should be the relative path from your project android build directory to the directory with facebook sdk):
+* In the Android package source directory add the project.properties file (or edit it) and append the following content (pay attention to android.library.reference.1, if you already added other library references you should ensure that the number is unique and progressive; moreover the path should be the relative path from your project android build directory to the directory with facebook sdk):
 ```
 # Project target.
 target=android-19
 ## Reference to the Facebook SDK
 android.library.reference.1=../../facebook
 ```
+
+### Integrating QtFacebook into your code
 * For a better integration of Facebook SDK, edit the AndroidManifest.xml and add the following tags into the <application> tag:
 ```
 <activity android:name="com.facebook.LoginActivity" android:label="@string/app_name" android:theme="@android:style/Theme.Translucent.NoTitleBar"></activity>

--- a/qfacebook_android.cpp
+++ b/qfacebook_android.cpp
@@ -303,7 +303,10 @@ static void fromJavaOnOperationDone(JNIEnv* env, jobject thiz, jstring operation
 		int count = env->GetArrayLength(data);
 		for( int i=0; i<count; i=i+2 ) {
 			QAndroidJniObject key( env->GetObjectArrayElement(data, i) );
-			QAndroidJniObject value( env->GetObjectArrayElement(data, i+1) );
+			QAndroidJniObject value;
+			if ((i+1) < count) {
+				value = env->GetObjectArrayElement(data, i+1);
+			}
 			dataMap[key.toString()] = value.toString();
 		}
 		QMetaObject::invokeMethod(QFacebook::instance(), "operationDone", Qt::QueuedConnection,

--- a/qfacebook_desktop.cpp
+++ b/qfacebook_desktop.cpp
@@ -65,6 +65,10 @@ void QFacebook::close() {
 	onFacebookStateChanged(SessionClosed, QStringList());
 }
 
+void QFacebook::requestMe() {
+	qDebug() << "Request Me";
+}
+
 void QFacebook::requestPublishPermissions() {
 	// Directly calling slot
 	onFacebookStateChanged(SessionOpenTokenExtended, QStringList());
@@ -100,6 +104,14 @@ void QFacebook::addRequestPermission( QString requestPermission ) {
 		requestPermissions.append( requestPermission );
 		emit requestPermissionsChanged(requestPermissions);
 	}
+}
+
+QString QFacebook::getAccessToken() {
+	return QString();
+}
+
+QString QFacebook::getExpirationDate() {
+	return QString();
 }
 
 void QFacebook::onApplicationStateChanged(Qt::ApplicationState state) {


### PR DESCRIPTION
The method to share links using the share dialog (and the feed dialog as a fallback) has been fixed and should now work correctly both with and without the facebook app. Moreover I modified instructions to document how to include the Facebook SDK using gradle and maven instead of ant
