### PR TITLE
add method to share image from QQuickItemGrabResult

### DIFF
--- a/qfacebook.cpp
+++ b/qfacebook.cpp
@@ -18,6 +18,7 @@
  * ********************************************************************** */
 
 #include "qfacebook.h"
+#include <QQuickItemGrabResult>
 
 QObject* QFacebook::qFacebookProvider(QQmlEngine *engine, QJSEngine *scriptEngine) {
 	Q_UNUSED(engine)
@@ -88,3 +89,7 @@ bool QFacebook::isReadPermission( QString permission ) {
 	return knowRead.contains( permission );
 }
 
+void QFacebook::publishQuickItemGrabResult(QQuickItemGrabResult *result, QString message)
+{
+    publishPhoto(QPixmap::fromImage(result->image()), message);
+}

--- a/qfacebook.h
+++ b/qfacebook.h
@@ -25,6 +25,7 @@
 #include <QPixmap>
 
 class QFacebookPlatformData;
+class QQuickItemGrabResult;
 
 #ifdef QFACEBOOK_NOT_DEFINE_JNI_ONLOAD
 typedef struct _JavaVM JavaVM;
@@ -115,6 +116,12 @@ public slots:
 	 *  \param message an optional description of the photo that will be shown in the feed story
 	 */
 	void publishPhoto( QPixmap photo, QString message=QString() );
+    /*! post a photo to the user wall
+     *  \param result the QQuickItem::grabToImage() result will be uploaded to the user album on Facebook
+     *  \param message an optional description of the photo that will be shown in the feed story
+     */
+    void publishQuickItemGrabResult( QQuickItemGrabResult *result, QString message=QString() );
+
 	/*! Publish a link with a photo using Share Dialog.
 	 *
 	 *  If the Share Dialog is not available (e.g. because the user hasn't the Facebook app installed),


### PR DESCRIPTION
It is useful to share QQuickItem's views as images
